### PR TITLE
chore: tweaks following end-to-end verification

### DIFF
--- a/.github/workflows/plugin-lint.yaml
+++ b/.github/workflows/plugin-lint.yaml
@@ -1,4 +1,4 @@
-name: bash-checks
+name: Plugin Linting & Testing
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Lint
-        run: docker-compose run --rm lint
+        run: docker compose run --rm lint
 
       - name: Test
-        run: docker-compose run --rm tests
+        run: docker compose run --rm tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.swp
 src/ecrscanresults
 src/*.html
+
+# GoReleaser artifacts
+src/dist

--- a/src/.goreleaser.yaml
+++ b/src/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: example-go-buildkite-plugin
     env:
@@ -20,7 +22,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   use: github-native

--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -11,6 +11,7 @@ type Config struct {
 type EnvironmentConfigFetcher struct {
 }
 
+// TODO: Replace "EXAMPLE_GO" with the name of your plugin, also in upper case
 const pluginEnvironmentPrefix = "BUILDKITE_PLUGIN_EXAMPLE_GO"
 
 func (f EnvironmentConfigFetcher) Fetch(config *Config) error {

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -13,11 +13,11 @@ load '../lib/download.bash'
 #export DOCKER_STUB_DEBUG=/dev/tty
 
 setup() {
-  export BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE=true
+  export BUILDKITE_PLUGIN_EXAMPLE_GO_BUILDKITE_PLUGIN_TEST_MODE=true
 }
 
 teardown() {
-    unset BUILDKITE_PLUGIN_ECR_SCAN_RESULTS_BUILDKITE_PLUGIN_TEST_MODE
+    unset BUILDKITE_PLUGIN_EXAMPLE_GO_BUILDKITE_PLUGIN_TEST_MODE
     rm ./example-go-buildkite-plugin || true
 }
 


### PR DESCRIPTION
# Purpose 🎯 

These changes apply minor tweaks following discoveries working on a simple end-to-end implementation using this template. 

1. While creating release artifacts using `GoReleaser`, these are written into the `src/dist` directory. In the event local releases are being made, we want to ignore these being potentially committed, or having `GoReleaser` require the `--clean` argument being passed (it verifies any current changes in git being tracked).
2. Buildkite plugin configurations manifest as environment variables named named after the plugin. When the template is being used, the const `pluginEnvironmentPrefix` needs to be updated to reflect the plugin name. Otherwise, the plugin config can't get picked up when executed.
3. When running `goreleaser lint`, the config in this project doesn't specify the GoReleaser version it supports, and uses a deprecated key for the `snapshot` object.
4. The `bash-checks` action is really a linting and testing of the Buildkite plugin using the [Buildkite validation and testing tools](https://buildkite.com/docs/pipelines/integrations/plugins/writing#step-3-validate-the-plugin) to make sure your plugin meets a minimum quality standard. Hence, this file has been renamed.

# Context 🧠 

- Outcome of discoveries in [CSRE-4965](https://cultureamp.atlassian.net/browse/CSRE-4965)

[CSRE-4965]: https://cultureamp.atlassian.net/browse/CSRE-4965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ