### PR TITLE
test: match error string when the environment variable is missing

### DIFF
--- a/src/plugin/config.go
+++ b/src/plugin/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Config struct {
-	Message string `envconfig:"MESSAGE" required:"true"`
+	Message string `required:"true"`
 }
 
 type EnvironmentConfigFetcher struct {

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -17,7 +17,8 @@ func TestFailOnMissingEnvironment(t *testing.T) {
 
 	err := fetcher.Fetch(&config)
 
-	assert.NotNil(t, err, "fetch should error")
+	expectedErr := "required key BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE missing value"
+	assert.EqualError(t, err, expectedErr, "fetch should error on missing environment variable")
 }
 
 func TestFetchConfigFromEnvironment(t *testing.T) {


### PR DESCRIPTION
# Purpose 🎯 

This change fixes a test that returns a false-positive. This occurred
because previously the check was for *any* error, not specifically
if the required environment variable was missing. This is fixed by
checking the error message, rather than naively checking for any error.

# Context 🧠 

- Identified while applying review feedback work on the `ecs-task-runner`: https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/1