### PR TITLE
test: os.Unsetenv affects global state

### DIFF
--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestFailOnMissingEnvironment(t *testing.T) {
-	unsetEnvironmentVariables()
-
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
+
+	unsetEnv(t, "BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE")
 
 	err := fetcher.Fetch(&config)
 
@@ -22,9 +22,6 @@ func TestFailOnMissingEnvironment(t *testing.T) {
 }
 
 func TestFetchConfigFromEnvironment(t *testing.T) {
-	unsetEnvironmentVariables()
-	defer unsetEnvironmentVariables()
-
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
 
@@ -36,8 +33,19 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 	assert.Equal(t, "test-message", config.Message, "fetched message should match environment")
 }
 
-// Unsets environment variables through an all-in-one function. Extend this with additional environment variables as
-// needed.
-func unsetEnvironmentVariables() {
-	os.Unsetenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE")
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	// ensure state is restored correctly
+	currValue, exists := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if exists {
+			os.Setenv(key, currValue)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
+
+	// clear the value
+	os.Unsetenv(key)
 }

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 func TestFailOnMissingEnvironment(t *testing.T) {
+	unsetEnvironmentVariables()
+
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
-
-	t.Setenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE", "")
-	os.Unsetenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE")
 
 	err := fetcher.Fetch(&config)
 
@@ -23,6 +22,9 @@ func TestFailOnMissingEnvironment(t *testing.T) {
 }
 
 func TestFetchConfigFromEnvironment(t *testing.T) {
+	unsetEnvironmentVariables()
+	defer unsetEnvironmentVariables()
+
 	var config plugin.Config
 	fetcher := plugin.EnvironmentConfigFetcher{}
 
@@ -32,4 +34,10 @@ func TestFetchConfigFromEnvironment(t *testing.T) {
 
 	require.NoError(t, err, "fetch should not error")
 	assert.Equal(t, "test-message", config.Message, "fetched message should match environment")
+}
+
+// Unsets environment variables through an all-in-one function. Extend this with additional environment variables as
+// needed.
+func unsetEnvironmentVariables() {
+	os.Unsetenv("BUILDKITE_PLUGIN_EXAMPLE_GO_MESSAGE")
 }


### PR DESCRIPTION
# Purpose 🎯 

This change adds a helper function that guarantees the cleanup of environment variables.

For each applicable test function, we run this at the start, and at the end through a `defer` keyword. Previously, we were unsetting the environment variable within the test, though there is a risk that since global state is being manipulated, we may run into a flakey test where an environment variable is inadvertently lingering.

# Context 🧠 

- Applies feedback brought up in `ecs-task-runner`: https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/1
- [Continues an ongoing pattern exercised throughout the org](https://github.com/search?q=org%3Acultureamp+unsetEnvironmentVariables+path%3A**%2F*_test.go&type=code)