### PR TITLE
fix: remove duplicate logging

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,13 +18,13 @@ COPY . ./
 # build as a static binary without debug symbols
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
       -ldflags='-w -s -extldflags "-static"' -a \
-      -o /dist/examplego .
+      -o /dist/example-go-buildkite-plugin .
 
 # runtime image using static distroless base
 # using static nonroot image
 # user:group is nobody:nobody, uid:gid = 65534:65534
 FROM ${DISTROLESS_IMAGE}
 
-COPY --from=builder /dist/examplego /examplego
+COPY --from=builder /dist/example-go-buildkite-plugin /example-go-buildkite-plugin
 
-ENTRYPOINT ["/examplego"]
+ENTRYPOINT ["/example-go-buildkite-plugin"]

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/cultureamp/examplego
+module github.com/cultureamp/example-go-buildkite-plugin
 
 go 1.20
 

--- a/src/main.go
+++ b/src/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 
-	"github.com/cultureamp/examplego/buildkite"
-	"github.com/cultureamp/examplego/plugin"
+	"github.com/cultureamp/example-go-buildkite-plugin/buildkite"
+	"github.com/cultureamp/example-go-buildkite-plugin/plugin"
 )
 
 func main() {

--- a/src/plugin/config_test.go
+++ b/src/plugin/config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cultureamp/examplego/plugin"
+	"github.com/cultureamp/example-go-buildkite-plugin/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/plugin/example.go
+++ b/src/plugin/example.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 
-	"github.com/cultureamp/examplego/buildkite"
+	"github.com/cultureamp/example-go-buildkite-plugin/buildkite"
 )
 
 type ExamplePlugin struct {

--- a/src/plugin/example.go
+++ b/src/plugin/example.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cultureamp/example-go-buildkite-plugin/buildkite"
 )
@@ -21,8 +22,7 @@ func (ep ExamplePlugin) Run(ctx context.Context, fetcher ConfigFetcher, agent Ag
 	var config Config
 	err := fetcher.Fetch(&config)
 	if err != nil {
-		buildkite.LogFailuref("plugin configuration error: %s\n", err.Error())
-		return err
+		return fmt.Errorf("plugin configuration error: %w", err)
 	}
 	annotation := config.Message
 
@@ -30,8 +30,7 @@ func (ep ExamplePlugin) Run(ctx context.Context, fetcher ConfigFetcher, agent Ag
 
 	err = agent.Annotate(ctx, annotation, "info", "message")
 	if err != nil {
-		buildkite.LogFailuref("buildkite annotation error: %s\n", err.Error())
-		return err
+		return fmt.Errorf("buildkite annotation error: %w", err)
 	}
 
 	buildkite.Log("done.")

--- a/src/plugin/example_test.go
+++ b/src/plugin/example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cultureamp/examplego/plugin"
+	"github.com/cultureamp/example-go-buildkite-plugin/plugin"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Renamed the Go module to match the repo name.

Errors are now wrapped and returned to the caller, rather than logged
and returned to the caller.

Propagating the error to the caller causes errors to logged by the
`main` function (if they're propagated that far). Logging them elsewhere
results in the error being logged more than once.

The idiomatic way of handling errors in Go is to return the error from the
called function, and have it handled in main before exiting.

Relates to https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/20 and https://github.com/cultureamp/ecs-task-runner-buildkite-plugin/pull/21